### PR TITLE
fix: `Time.utc_now` has been renamed `Time.utc` in standard library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can `#postpone` and `#reschedule` a timer. The latter has bigger
 performance impact if rescheduling at an earlier moment of time.
 
 ```
-at = Time.utc_now + 5.minutes
+at = Time.utc + 5.minutes
 
 timer = Timer.new(at) do
   puts "Triggered"
@@ -75,10 +75,10 @@ end
 timer.postpone(1.minute)
 
 # ditto
-timer.reschedule(Time.utc_now + 6.minutes)
+timer.reschedule(Time.utc + 6.minutes)
 
 # Worse performance but still acceptable
-timer.reschedule(Time.utc_now + 1.minute)
+timer.reschedule(Time.utc + 1.minute)
 ```
 
 Note that a timer can be scheduled at a moment in the past, which means that it

--- a/spec/timer_spec.cr
+++ b/spec/timer_spec.cr
@@ -16,7 +16,7 @@ describe Timer do
   it "works with Time" do
     foo = nil
 
-    timer = Timer.new(Time.utc_now + 0.5.seconds) do
+    timer = Timer.new(Time.utc + 0.5.seconds) do
       foo = "bar"
     end
 
@@ -62,7 +62,7 @@ describe Timer do
 
       sleep(0.1.seconds)
 
-      timer.reschedule(Time.utc_now + 0.2.seconds)
+      timer.reschedule(Time.utc + 0.2.seconds)
 
       sleep(0.1.seconds)
       foo.should be_nil
@@ -80,10 +80,10 @@ describe Timer do
 
       sleep(0.1.seconds)
 
-      timer.reschedule(Time.utc_now + 0.2.seconds)
+      timer.reschedule(Time.utc + 0.2.seconds)
 
       sleep(0.1.seconds)
-      timer.reschedule(Time.utc_now + 0.2.seconds)
+      timer.reschedule(Time.utc + 0.2.seconds)
 
       sleep(0.1.seconds)
       foo.should be_nil

--- a/src/timer.cr
+++ b/src/timer.cr
@@ -29,7 +29,7 @@
 # performance impact if rescheduling at an earlier moment of time.
 #
 # ```
-# at = Time.utc_now + 5.minutes
+# at = Time.utc + 5.minutes
 #
 # timer = Timer.new(at) do
 #   puts "Triggered"
@@ -39,10 +39,10 @@
 # timer.postpone(1.minute)
 #
 # # ditto
-# timer.reschedule(Time.utc_now + 6.minutes)
+# timer.reschedule(Time.utc + 6.minutes)
 #
 # # Worse performance but still acceptable
-# timer.reschedule(Time.utc_now + 1.minute)
+# timer.reschedule(Time.utc + 1.minute)
 # ```
 #
 # Note that a timer can be scheduled at a moment in the past, which means that it
@@ -82,7 +82,7 @@ class Timer
 
   # Execute the *block* *in* some time span.
   def self.new(in : Time::Span, &block)
-    new(Time.utc_now + in, &block)
+    new(Time.utc + in, &block)
   end
 
   # :nodoc:
@@ -138,7 +138,7 @@ class Timer
   protected def schedule(fiber_id = rand)
     spawn do
       loop do
-        sleep({Time::Span.zero, @at - Time.utc_now}.max)
+        sleep({Time::Span.zero, @at - Time.utc}.max)
 
         if @completed || @cancelled
           break
@@ -148,7 +148,7 @@ class Timer
           break
         end
 
-        if Time.utc_now < @at
+        if Time.utc < @at
           next
         end
 


### PR DESCRIPTION
As of crystal 0.35.0, `Time.utc_now` has been renamed `Time.utc`